### PR TITLE
Adding Sentry error tracking

### DIFF
--- a/MultiplayerDemo/MultiplayerDemo.csproj
+++ b/MultiplayerDemo/MultiplayerDemo.csproj
@@ -64,7 +64,24 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libs\NeutrinoCore.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Sentry, Version=0.0.1.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.0.0.1-preview3\lib\netstandard2.0\Sentry.dll</HintPath>
+    </Reference>
+    <Reference Include="Sentry.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.PlatformAbstractions.1.0.0-dev-00071\lib\net45\Sentry.PlatformAbstractions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/MultiplayerDemo/Program.cs
+++ b/MultiplayerDemo/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Sentry;
 
 namespace MultiplayerDemo
 {
@@ -13,6 +14,8 @@ namespace MultiplayerDemo
         [STAThread]
         static void Main()
         {
+            SentrySdk.Init("https://5fd7a6cda8444965bade9ccfd3df9882@sentry.io/1188141");
+
             using (var game = new Game1())
                 game.Run();
         }

--- a/MultiplayerDemo/app.config
+++ b/MultiplayerDemo/app.config
@@ -1,3 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/MultiplayerDemo/packages.config
+++ b/MultiplayerDemo/packages.config
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="LiteNetLib" version="0.7.7.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Sentry" version="0.0.1-preview3" targetFramework="net461" />
+  <package id="Sentry.PlatformAbstractions" version="1.0.0-dev-00071" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
I wanted to test the new [Sentry SDK](https://github.com/getsentry/sentry-dotnet/) I've been working on with MonoGame so I used your demo game for that :)

It works great, with simply `SentrySdk.Init` it automatically tracks unhandled exceptions that crash the game and send to [Sentry](https://sentry.io). I think this could be very useful to game devs using MonoGame:

![image](https://user-images.githubusercontent.com/1633368/43071459-2f2880d2-8e73-11e8-9a8c-315f50d00881.png)
![image](https://user-images.githubusercontent.com/1633368/43071480-417f0e4a-8e73-11e8-9ca8-75f0ed01cd0e.png)

If you find this interesting, you can take your own DSN at sentry.io and replace the one I used in this PR. Also, sentry.io is [free for up to 10k events](https://sentry.io/pricing/).
[Sentry is on GitHub](https://github.com/getsentry/sentry).